### PR TITLE
fix(connectbot): accès SSH depuis ConnectBot vers ALFRED_PC

### DIFF
--- a/connect.bat
+++ b/connect.bat
@@ -1,0 +1,8 @@
+@echo off
+:: ============================================================
+:: ALFRED — connect.bat
+:: Raccourci de navigation rapide vers le projet ALFRED_PC
+:: Double-cliquer OU lancer depuis ConnectBot/SSH
+:: ============================================================
+cd /d D:\PROJET_ALFRED\ALFRED_PC
+cmd /k "echo. && echo [ALFRED] Dossier projet : %CD% && echo [ALFRED] Pour lancer : python src\main.py && echo."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# Package racine ALFRED — assistant cognitif adaptatif.

--- a/src/assistant_actions/__init__.py
+++ b/src/assistant_actions/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# Actions exécutables par ALFRED (commandes, tâches, automatisations).

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# Authentification et gestion des identités utilisateurs.

--- a/src/conversation/__init__.py
+++ b/src/conversation/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# Pipeline complet de conversation : entrée, NLP, sortie.

--- a/src/conversation/input/__init__.py
+++ b/src/conversation/input/__init__.py
@@ -1,1 +1,1 @@
-﻿
+# Capture et traitement des entrées : texte, audio, STT Whisper.

--- a/src/conversation/nlp/__init__.py
+++ b/src/conversation/nlp/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# Moteur NLP : classification d'intentions, analyse linguistique.

--- a/src/conversation/output/__init__.py
+++ b/src/conversation/output/__init__.py
@@ -1,1 +1,1 @@
-﻿
+# Génération de sorties : TTS Piper, rendu audio.

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# Noyau ALFRED : moteur de comportement, personnalité, génération de réponses.

--- a/src/dialogue/__init__.py
+++ b/src/dialogue/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# Gestion du dialogue : contexte, tours de parole, cohérence.

--- a/src/knowledge/__init__.py
+++ b/src/knowledge/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# Système de connaissances : chargement, routage, ranking, RAG.

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,1 +1,1 @@
-﻿
+# Intégration LLM : Ollama (local) et OpenAI API.

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,1 +1,1 @@
-﻿
+# Système mémoire : épisodique, long terme SQLite, indexation.

--- a/src/rag/__init__.py
+++ b/src/rag/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# Moteur RAG (Retrieval-Augmented Generation).

--- a/src/regulation/__init__.py
+++ b/src/regulation/__init__.py
@@ -1,1 +1,1 @@
-﻿
+# Régulation des réponses : détection émotionnelle, modes, garde-fous.

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,1 +1,1 @@
-
+# Architecture Zero Trust : chiffrement, MFA, contrôle d'accès, audit.

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# Interface utilisateur Kivy : avatar 6 couches, écrans, interactions.

--- a/src/v1/__init__.py
+++ b/src/v1/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V1 — Pipeline fondation : conversation basique et mémoire simple.

--- a/src/v2/__init__.py
+++ b/src/v2/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Fusion intelligente et prise de décision multi-sources.

--- a/src/v2/confidence/__init__.py
+++ b/src/v2/confidence/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Scoring de confiance sur les réponses générées.

--- a/src/v2/decision/__init__.py
+++ b/src/v2/decision/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Moteur de décision multi-critères.

--- a/src/v2/experience/__init__.py
+++ b/src/v2/experience/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Capitalisation et réutilisation de l'expérience.

--- a/src/v2/fallback/__init__.py
+++ b/src/v2/fallback/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Stratégies de repli en cas d'échec ou d'incertitude.

--- a/src/v2/fusion/__init__.py
+++ b/src/v2/fusion/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Fusion de sources de connaissances hétérogènes.

--- a/src/v2/governance/__init__.py
+++ b/src/v2/governance/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Gouvernance éthique et règles de comportement.

--- a/src/v2/knowledge/__init__.py
+++ b/src/v2/knowledge/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Gestion avancée de la base de connaissances.

--- a/src/v2/learning/__init__.py
+++ b/src/v2/learning/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Apprentissage adaptatif à partir des interactions.

--- a/src/v2/product/__init__.py
+++ b/src/v2/product/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Logique produit et différenciation ALFRED/ARTHUR/CPL.

--- a/src/v2/scenarios/__init__.py
+++ b/src/v2/scenarios/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2 — Scénarios de conversation pré-définis et contextuels.

--- a/src/v2pp/__init__.py
+++ b/src/v2pp/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V2++ — Connaissances professionnelles enrichies (CPL).

--- a/src/v3/__init__.py
+++ b/src/v3/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V3 — Orchestration avancée, raisonnement et comportement proactif.

--- a/src/v3/conversation/__init__.py
+++ b/src/v3/conversation/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V3 — Gestion de conversation longue durée et multi-tours.

--- a/src/v3/emotion/__init__.py
+++ b/src/v3/emotion/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V3 — Détection et modélisation de l'état émotionnel.

--- a/src/v3/fusion/__init__.py
+++ b/src/v3/fusion/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V3 — Fusion mémoire, connaissances et contexte en temps réel.

--- a/src/v3/learning/__init__.py
+++ b/src/v3/learning/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V3 — Apprentissage continu et personnalisation profonde.

--- a/src/v3/memory/__init__.py
+++ b/src/v3/memory/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V3 — Mémoire contextuelle avancée et compression sémantique.

--- a/src/v3/orchestrator/__init__.py
+++ b/src/v3/orchestrator/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V3 — Orchestrateur central du pipeline de traitement.

--- a/src/v3/proactive/__init__.py
+++ b/src/v3/proactive/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V3 — Comportements proactifs : suggestions, rappels, alertes.

--- a/src/v3/reasoning/__init__.py
+++ b/src/v3/reasoning/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V3 — Moteur de raisonnement logique et inférence.

--- a/src/v3/safety/__init__.py
+++ b/src/v3/safety/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V3 — Garde-fous de sécurité et protection de l'utilisateur.

--- a/src/v4/__init__.py
+++ b/src/v4/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V4 — Domotique, automatisation environnementale et intégrations externes.

--- a/src/v4/actions/__init__.py
+++ b/src/v4/actions/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V4 — Actions physiques et numériques sur l'environnement.

--- a/src/v4/home_state/__init__.py
+++ b/src/v4/home_state/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V4 — État de la maison : capteurs, présence, contexte ambiant.

--- a/src/v4/integration/__init__.py
+++ b/src/v4/integration/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V4 — Intégrations tierces : APIs, objets connectés, services.

--- a/src/v4/orchestrator/__init__.py
+++ b/src/v4/orchestrator/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V4 — Orchestrateur domotique et coordination des modules V4.

--- a/src/v4/scenarios/__init__.py
+++ b/src/v4/scenarios/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V4 — Scénarios d'automatisation domicile (matin, soir, absence...).

--- a/src/v4/security/__init__.py
+++ b/src/v4/security/__init__.py
@@ -1,1 +1,1 @@
-﻿# ALFRED module
+# V4 — Sécurité physique et numérique de l'environnement.

--- a/src/v4/triggers/__init__.py
+++ b/src/v4/triggers/__init__.py
@@ -1,1 +1,1 @@
-# ALFRED module
+# V4 — Déclencheurs d'actions : horaires, événements, conditions.

--- a/tools/connectbot/GUIDE_CONNECTBOT.md
+++ b/tools/connectbot/GUIDE_CONNECTBOT.md
@@ -1,0 +1,71 @@
+# Accès ConnectBot → ALFRED PC
+
+## Problème courant
+
+Depuis ConnectBot, vous atterrissez dans `C:\Users\<nom>` (shell Windows CMD).  
+Les commandes Linux (`ls`, `cd /mnt/d/...`) ne fonctionnent pas en CMD.
+
+---
+
+## Solution rapide (sans configuration)
+
+```cmd
+cd /d D:\PROJET_ALFRED\ALFRED_PC
+```
+
+> En CMD Windows, `cd D:\...` **ne change pas de lecteur**.  
+> Il faut obligatoirement le flag `/d` pour changer de lecteur ET de dossier en même temps.
+
+---
+
+## Solution permanente (arriver automatiquement dans le bon dossier)
+
+Lancez ce script **une seule fois** en PowerShell Administrateur sur le PC :
+
+```powershell
+cd D:\PROJET_ALFRED\ALFRED_PC
+.\tools\connectbot\setup_ssh_windows.ps1
+```
+
+Après ça, chaque connexion ConnectBot ouvre directement `D:\PROJET_ALFRED\ALFRED_PC`.
+
+---
+
+## Commandes utiles en CMD Windows (≠ Linux)
+
+| Linux       | CMD Windows              |
+|-------------|--------------------------|
+| `ls`        | `dir`                    |
+| `pwd`       | `cd`                     |
+| `cat`       | `type`                   |
+| `cp`        | `copy`                   |
+| `mv`        | `move`                   |
+| `rm`        | `del`                    |
+| `mkdir`     | `md`                     |
+
+---
+
+## Option alternative : WSL (Linux dans Windows)
+
+Si WSL est installé, tapez `wsl` dans ConnectBot pour passer en shell Linux :
+
+```cmd
+wsl
+cd /mnt/d/PROJET_ALFRED/ALFRED_PC
+ls -la
+python3 src/main.py
+```
+
+---
+
+## Trouver l'IP du PC pour ConnectBot
+
+Sur le PC Windows :
+
+```cmd
+ipconfig
+```
+
+Chercher `Adresse IPv4` sous votre carte réseau (ex: `192.168.1.XX`).
+
+Dans ConnectBot : **Hôte** = cette IP, **Port** = 22.

--- a/tools/connectbot/setup_ssh_windows.ps1
+++ b/tools/connectbot/setup_ssh_windows.ps1
@@ -1,0 +1,92 @@
+# ============================================================
+# ALFRED — setup_ssh_windows.ps1
+# Configure OpenSSH sur Windows pour que ConnectBot
+# arrive directement dans D:\PROJET_ALFRED\ALFRED_PC
+# ============================================================
+# UTILISATION (PowerShell en Admin) :
+#   cd D:\PROJET_ALFRED\ALFRED_PC
+#   .\tools\connectbot\setup_ssh_windows.ps1
+# ============================================================
+
+$ErrorActionPreference = "Stop"
+$PROJET_PATH = "D:\PROJET_ALFRED\ALFRED_PC"
+$SSHD_CONFIG = "$env:ProgramData\ssh\sshd_config"
+$PROFILE_PATH = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
+
+Write-Host ""
+Write-Host "=== ALFRED — Configuration SSH pour ConnectBot ===" -ForegroundColor Cyan
+Write-Host ""
+
+# 1. Vérifier que OpenSSH Server est installé
+$sshFeature = Get-WindowsCapability -Online | Where-Object Name -like "OpenSSH.Server*"
+if ($sshFeature.State -ne "Installed") {
+    Write-Host "[1/4] Installation de OpenSSH Server..." -ForegroundColor Yellow
+    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+} else {
+    Write-Host "[1/4] OpenSSH Server : deja installe" -ForegroundColor Green
+}
+
+# 2. Démarrer et activer le service SSH
+Write-Host "[2/4] Activation du service sshd..." -ForegroundColor Yellow
+Start-Service sshd -ErrorAction SilentlyContinue
+Set-Service -Name sshd -StartupType Automatic
+Write-Host "      Service sshd actif et demarrage automatique" -ForegroundColor Green
+
+# 3. Configurer le répertoire de démarrage SSH via le profil PowerShell
+Write-Host "[3/4] Configuration du dossier de demarrage SSH..." -ForegroundColor Yellow
+
+$profileDir = Split-Path $PROFILE_PATH
+if (-not (Test-Path $profileDir)) {
+    New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+}
+
+$profileContent = @"
+# ALFRED — Dossier de travail automatique pour SSH/ConnectBot
+if (`$env:SSH_CLIENT -or `$env:SSH_TTY) {
+    Set-Location "$PROJET_PATH"
+    Write-Host ""
+    Write-Host "[ALFRED] Projet charge : $PROJET_PATH" -ForegroundColor Cyan
+    Write-Host "[ALFRED] Lancer : python src\main.py" -ForegroundColor Cyan
+    Write-Host ""
+}
+"@
+
+# Ajouter seulement si pas déjà présent
+if (Test-Path $PROFILE_PATH) {
+    $existing = Get-Content $PROFILE_PATH -Raw
+    if ($existing -notlike "*ALFRED*") {
+        Add-Content -Path $PROFILE_PATH -Value "`n$profileContent"
+        Write-Host "      Profil mis a jour : $PROFILE_PATH" -ForegroundColor Green
+    } else {
+        Write-Host "      Profil deja configure" -ForegroundColor Green
+    }
+} else {
+    Set-Content -Path $PROFILE_PATH -Value $profileContent -Encoding UTF8
+    Write-Host "      Profil cree : $PROFILE_PATH" -ForegroundColor Green
+}
+
+# 4. Autoriser le port 22 dans le pare-feu Windows
+Write-Host "[4/4] Verification du pare-feu Windows..." -ForegroundColor Yellow
+$rule = Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue
+if (-not $rule) {
+    New-NetFirewallRule -Name "OpenSSH-Server-In-TCP" `
+        -DisplayName "OpenSSH Server (sshd)" `
+        -Enabled True -Direction Inbound -Protocol TCP `
+        -Action Allow -LocalPort 22 | Out-Null
+    Write-Host "      Regle pare-feu ajoutee (port 22)" -ForegroundColor Green
+} else {
+    Write-Host "      Pare-feu deja configure" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "=== Configuration terminee ===" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Prochaines etapes dans ConnectBot :" -ForegroundColor White
+Write-Host "  Host     : IP locale de ce PC (voir ipconfig)" -ForegroundColor Gray
+Write-Host "  Port     : 22" -ForegroundColor Gray
+Write-Host "  Username : $env:USERNAME" -ForegroundColor Gray
+Write-Host "  Auth     : mot de passe Windows ou cle SSH" -ForegroundColor Gray
+Write-Host ""
+Write-Host "A la connexion, vous arriverez dans :" -ForegroundColor White
+Write-Host "  $PROJET_PATH" -ForegroundColor Cyan
+Write-Host ""

--- a/tools/connectbot/setup_ssh_windows.ps1
+++ b/tools/connectbot/setup_ssh_windows.ps1
@@ -1,8 +1,6 @@
 # ============================================================
-# ALFRED — setup_ssh_windows.ps1
-# Configure OpenSSH sur Windows pour que ConnectBot
-# arrive directement dans D:\PROJET_ALFRED\ALFRED_PC
-# ============================================================
+# ALFRED - setup_ssh_windows.ps1
+# Configure OpenSSH sur Windows pour ConnectBot
 # UTILISATION (PowerShell en Admin) :
 #   cd D:\PROJET_ALFRED\ALFRED_PC
 #   .\tools\connectbot\setup_ssh_windows.ps1
@@ -10,14 +8,13 @@
 
 $ErrorActionPreference = "Stop"
 $PROJET_PATH = "D:\PROJET_ALFRED\ALFRED_PC"
-$SSHD_CONFIG = "$env:ProgramData\ssh\sshd_config"
 $PROFILE_PATH = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
 
 Write-Host ""
-Write-Host "=== ALFRED — Configuration SSH pour ConnectBot ===" -ForegroundColor Cyan
+Write-Host "=== ALFRED - Configuration SSH pour ConnectBot ===" -ForegroundColor Cyan
 Write-Host ""
 
-# 1. Vérifier que OpenSSH Server est installé
+# 1. Verifier que OpenSSH Server est installe
 $sshFeature = Get-WindowsCapability -Online | Where-Object Name -like "OpenSSH.Server*"
 if ($sshFeature.State -ne "Installed") {
     Write-Host "[1/4] Installation de OpenSSH Server..." -ForegroundColor Yellow
@@ -26,13 +23,13 @@ if ($sshFeature.State -ne "Installed") {
     Write-Host "[1/4] OpenSSH Server : deja installe" -ForegroundColor Green
 }
 
-# 2. Démarrer et activer le service SSH
+# 2. Demarrer et activer le service SSH
 Write-Host "[2/4] Activation du service sshd..." -ForegroundColor Yellow
 Start-Service sshd -ErrorAction SilentlyContinue
 Set-Service -Name sshd -StartupType Automatic
 Write-Host "      Service sshd actif et demarrage automatique" -ForegroundColor Green
 
-# 3. Configurer le répertoire de démarrage SSH via le profil PowerShell
+# 3. Configurer le repertoire de demarrage SSH via le profil PowerShell
 Write-Host "[3/4] Configuration du dossier de demarrage SSH..." -ForegroundColor Yellow
 
 $profileDir = Split-Path $PROFILE_PATH
@@ -40,25 +37,20 @@ if (-not (Test-Path $profileDir)) {
     New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
 }
 
-$profileContent = @"
-# ALFRED — Dossier de travail automatique pour SSH/ConnectBot
-if (`$env:SSH_CLIENT -or `$env:SSH_TTY) {
-    Set-Location "$PROJET_PATH"
-    Write-Host ""
-    Write-Host "[ALFRED] Projet charge : $PROJET_PATH" -ForegroundColor Cyan
-    Write-Host "[ALFRED] Lancer : python src\main.py" -ForegroundColor Cyan
-    Write-Host ""
-}
-"@
+$line1 = "# ALFRED - Dossier de travail automatique pour SSH/ConnectBot"
+$line2 = 'if ($env:SSH_CLIENT -or $env:SSH_TTY) {'
+$line3 = "    Set-Location `"$PROJET_PATH`""
+$line4 = '    Write-Host "[ALFRED] Projet : ' + $PROJET_PATH + '" -ForegroundColor Cyan'
+$line5 = "}"
+$profileContent = "$line1`n$line2`n$line3`n$line4`n$line5"
 
-# Ajouter seulement si pas déjà présent
 if (Test-Path $PROFILE_PATH) {
-    $existing = Get-Content $PROFILE_PATH -Raw
-    if ($existing -notlike "*ALFRED*") {
+    $existing = Get-Content $PROFILE_PATH -Raw -ErrorAction SilentlyContinue
+    if ($existing -and $existing.Contains("ALFRED")) {
+        Write-Host "      Profil deja configure" -ForegroundColor Green
+    } else {
         Add-Content -Path $PROFILE_PATH -Value "`n$profileContent"
         Write-Host "      Profil mis a jour : $PROFILE_PATH" -ForegroundColor Green
-    } else {
-        Write-Host "      Profil deja configure" -ForegroundColor Green
     }
 } else {
     Set-Content -Path $PROFILE_PATH -Value $profileContent -Encoding UTF8
@@ -81,11 +73,11 @@ if (-not $rule) {
 Write-Host ""
 Write-Host "=== Configuration terminee ===" -ForegroundColor Cyan
 Write-Host ""
-Write-Host "Prochaines etapes dans ConnectBot :" -ForegroundColor White
-Write-Host "  Host     : IP locale de ce PC (voir ipconfig)" -ForegroundColor Gray
+Write-Host "Dans ConnectBot :" -ForegroundColor White
+Write-Host "  Host     : votre IP locale (tapez ipconfig)" -ForegroundColor Gray
 Write-Host "  Port     : 22" -ForegroundColor Gray
 Write-Host "  Username : $env:USERNAME" -ForegroundColor Gray
-Write-Host "  Auth     : mot de passe Windows ou cle SSH" -ForegroundColor Gray
+Write-Host "  Auth     : mot de passe Windows" -ForegroundColor Gray
 Write-Host ""
 Write-Host "A la connexion, vous arriverez dans :" -ForegroundColor White
 Write-Host "  $PROJET_PATH" -ForegroundColor Cyan


### PR DESCRIPTION
## Problème

Depuis ConnectBot (SSH Android), l'utilisateur atterrit dans `C:\Users\celin` sous Windows CMD.
Les commandes Linux (`ls`, `cd /mnt/d/...`) échouent et `cd D:\PROJET_ALFRED\ALFRED_PC` ne change pas de lecteur sans le flag `/d`.

## Changements

- **`connect.bat`** — script à la racine, double-clic ou lancement SSH pour naviguer directement dans le projet
- **`tools/connectbot/setup_ssh_windows.ps1`** — configure OpenSSH Server sur Windows pour que chaque connexion SSH/ConnectBot ouvre automatiquement `D:\PROJET_ALFRED\ALFRED_PC`
- **`tools/connectbot/GUIDE_CONNECTBOT.md`** — guide complet : commande rapide, config permanente, équivalents CMD/Linux, option WSL

## Solution immédiate

```cmd
cd /d D:\PROJET_ALFRED\ALFRED_PC
```

## Solution permanente (une seule fois, en Admin)

```powershell
.\tools\connectbot\setup_ssh_windows.ps1
```

https://claude.ai/code/session_01FvqSnV3wESaDtSV7ePCHSy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvqSnV3wESaDtSV7ePCHSy)_