### PR TITLE
feat(v3): AlfredOrchestrator + RAG ChromaDB engine

### DIFF
--- a/src/rag/__init__.py
+++ b/src/rag/__init__.py
@@ -1,1 +1,4 @@
-﻿# ALFRED module
+from src.rag.rag_engine import RAGEngine
+from src.rag.chroma_store import ChromaStore
+
+__all__ = ["RAGEngine", "ChromaStore"]

--- a/src/rag/chroma_store.py
+++ b/src/rag/chroma_store.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""
+chroma_store.py — ALFRED V3
+Wrapper ChromaDB avec fallback keyword si chromadb non installé.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class ChromaStore:
+    """
+    Abstraction sur ChromaDB.
+    Si chromadb n'est pas installé, bascule en recherche keyword.
+    """
+
+    def __init__(
+        self,
+        persist_directory: str = "data/memory/chroma",
+        collection_name: str = "alfred_memory",
+    ):
+        self._available = False
+        self._client = None
+        self._collection = None
+        self._collection_name = collection_name
+        self._fallback_store: List[Dict[str, Any]] = []
+
+        try:
+            import chromadb
+
+            Path(persist_directory).mkdir(parents=True, exist_ok=True)
+            self._client = chromadb.PersistentClient(path=persist_directory)
+            self._collection = self._client.get_or_create_collection(
+                name=collection_name,
+                metadata={"hnsw:space": "cosine"},
+            )
+            self._available = True
+        except Exception:
+            pass
+
+    @property
+    def is_available(self) -> bool:
+        return self._available
+
+    def add(self, text: str, doc_id: str, metadata: Dict[str, Any] | None = None) -> bool:
+        if not text or not doc_id:
+            return False
+
+        if self._available:
+            try:
+                self._collection.upsert(
+                    documents=[text],
+                    ids=[doc_id],
+                    metadatas=[metadata or {}],
+                )
+                return True
+            except Exception:
+                return False
+
+        # Fallback keyword store
+        self._fallback_store.append(
+            {"id": doc_id, "document": text, "metadata": metadata or {}}
+        )
+        return True
+
+    def search(self, query: str, n_results: int = 5) -> List[Dict[str, Any]]:
+        if not query:
+            return []
+
+        if self._available:
+            try:
+                count = self._collection.count()
+                if count == 0:
+                    return []
+                results = self._collection.query(
+                    query_texts=[query],
+                    n_results=min(n_results, count),
+                )
+                docs = results.get("documents", [[]])[0]
+                metas = results.get("metadatas", [[]])[0]
+                distances = results.get("distances", [[]])[0]
+                return [
+                    {
+                        "document": doc,
+                        "metadata": meta,
+                        "score": max(0.0, 1.0 - dist),
+                    }
+                    for doc, meta, dist in zip(docs, metas, distances)
+                ]
+            except Exception:
+                return []
+
+        # Fallback keyword search
+        terms = re.findall(r"\w+", query.lower())
+        scored: List[tuple[float, Dict[str, Any]]] = []
+        for entry in self._fallback_store:
+            doc_lower = entry["document"].lower()
+            hits = sum(1 for t in terms if t in doc_lower)
+            if hits > 0:
+                scored.append((hits / max(len(terms), 1), entry))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [
+            {"document": e["document"], "metadata": e["metadata"], "score": s}
+            for s, e in scored[:n_results]
+        ]
+
+    def count(self) -> int:
+        if self._available:
+            try:
+                return self._collection.count()
+            except Exception:
+                return 0
+        return len(self._fallback_store)
+
+    def get_status(self) -> Dict[str, Any]:
+        return {
+            "available": self._available,
+            "backend": "chromadb" if self._available else "keyword_fallback",
+            "count": self.count(),
+            "collection": self._collection_name,
+        }

--- a/src/rag/rag_engine.py
+++ b/src/rag/rag_engine.py
@@ -1,9 +1,110 @@
+# -*- coding: utf-8 -*-
+"""
+rag_engine.py — ALFRED V3
+Moteur RAG : indexation et recherche sémantique des mémoires.
+
+Backend : ChromaDB local (fallback keyword si non installé).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.rag.chroma_store import ChromaStore
+
+
 class RAGEngine:
-    def __init__(self):
-        self.knowledge = []
+    """
+    Indexe les échanges et les documents, puis les retrouve par similarité sémantique.
 
-    def load(self, data):
-        self.knowledge.extend(data)
+    Deux collections :
+    - memory  : échanges utilisateur/ALFRED
+    - knowledge : documents de connaissance
+    """
 
-    def search(self, query: str):
-        return [k for k in self.knowledge if query.lower() in k.lower()]
+    def __init__(
+        self,
+        persist_directory: str = "data/memory/chroma",
+    ):
+        self._memory_store = ChromaStore(
+            persist_directory=persist_directory,
+            collection_name="alfred_memory",
+        )
+        self._knowledge_store = ChromaStore(
+            persist_directory=persist_directory,
+            collection_name="alfred_knowledge",
+        )
+
+    # ── Indexation ────────────────────────────────────────
+
+    def index_exchange(
+        self,
+        user_input: str,
+        response: str,
+        session_id: str,
+        turn: int,
+    ) -> None:
+        """Indexe un échange utilisateur/ALFRED dans la mémoire sémantique."""
+        doc_id = f"{session_id}_t{turn}"
+        text = f"Utilisateur : {user_input}\nALFRED : {response}"
+        metadata = {
+            "session_id": session_id,
+            "turn": turn,
+            "role": "exchange",
+        }
+        self._memory_store.add(text=text, doc_id=doc_id, metadata=metadata)
+
+    def index_document(
+        self,
+        text: str,
+        doc_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Indexe un document de connaissance."""
+        return self._knowledge_store.add(
+            text=text,
+            doc_id=doc_id,
+            metadata=metadata or {},
+        )
+
+    # ── Recherche ─────────────────────────────────────────
+
+    def search_memories(
+        self,
+        query: str,
+        n_results: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Recherche sémantique dans la mémoire conversationnelle."""
+        return self._memory_store.search(query=query, n_results=n_results)
+
+    def search_knowledge(
+        self,
+        query: str,
+        n_results: int = 3,
+    ) -> List[Dict[str, Any]]:
+        """Recherche sémantique dans la base de connaissance."""
+        return self._knowledge_store.search(query=query, n_results=n_results)
+
+    def search_all(
+        self,
+        query: str,
+        n_results: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Fusionne mémoire + knowledge, trie par pertinence."""
+        mem = self._memory_store.search(query=query, n_results=n_results)
+        know = self._knowledge_store.search(query=query, n_results=n_results)
+        merged = mem + know
+        merged.sort(key=lambda r: r.get("score", 0.0), reverse=True)
+        return merged[:n_results]
+
+    # ── Statut ────────────────────────────────────────────
+
+    @property
+    def is_available(self) -> bool:
+        return self._memory_store.is_available or self._knowledge_store.is_available
+
+    def get_status(self) -> Dict[str, Any]:
+        return {
+            "memory": self._memory_store.get_status(),
+            "knowledge": self._knowledge_store.get_status(),
+        }

--- a/src/v3/main_alfred_v3.py
+++ b/src/v3/main_alfred_v3.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""
+main_alfred_v3.py — ALFRED V3 — Point d'entrée orchestrateur
+
+Remplace le pipeline manuel de main.py par AlfredOrchestrator.
+Avatar/TTS non branché — pipeline texte uniquement.
+
+Usage :
+    python -m src.v3.main_alfred_v3
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.v3.orchestrator import AlfredOrchestrator
+
+# ── Chemins ───────────────────────────────────────────────
+PERSONALITY_PATH = str(
+    ROOT / "data" / "personality" / "instances" / "personality_core_instance.json"
+)
+USER_PROFILE_PATH = str(
+    ROOT / "data" / "users" / "instances" / "user_celine_instance.json"
+)
+MEMORY_PATH = str(
+    ROOT / "data" / "memory" / "episodic" / "dialogue_history.json"
+)
+
+# ── Commandes intégrées ───────────────────────────────────
+COMMANDS = {
+    "exit": lambda orch: ("exit", None),
+    "quit": lambda orch: ("exit", None),
+    "statut": lambda orch: ("print", _format_status(orch.get_status())),
+    "reset": lambda orch: ("reset", None),
+    "mode support": lambda orch: ("mode", "support"),
+    "mode focus": lambda orch: ("mode", "focus"),
+    "mode challenge": lambda orch: ("mode", "challenge"),
+    "mode complicite": lambda orch: ("mode", "complicite"),
+}
+
+
+def _format_status(status: dict) -> str:
+    session = status.get("session", {})
+    modules = status.get("modules", {})
+    rag = status.get("rag", {})
+    lines = [
+        f"── Session {session.get('session_id')} — Tour {session.get('turn_count')} ──",
+        f"Mode : {session.get('current_mode')} | Émotion : {session.get('current_emotion')}",
+        f"Wellbeing : {session.get('wellbeing_energy')}",
+        "",
+        "Modules chargés :",
+    ]
+    for k, v in modules.items():
+        lines.append(f"  {'✓' if v else '✗'} {k}")
+    mem_status = rag.get("memory", {})
+    lines.append(
+        f"\nRAG : {mem_status.get('backend', '?')} — "
+        f"{mem_status.get('count', 0)} documents indexés"
+    )
+    return "\n".join(lines)
+
+
+def run() -> None:
+    print("\n" + "=" * 50)
+    print("  ALFRED V3 — Orchestrateur cognitif adaptatif")
+    print("  'exit' pour quitter | 'statut' pour l'état")
+    print("=" * 50 + "\n")
+
+    orch = AlfredOrchestrator(
+        personality_path=PERSONALITY_PATH,
+        user_profile_path=USER_PROFILE_PATH,
+        memory_path=MEMORY_PATH,
+        debug=False,
+    )
+
+    status = orch.get_status()
+    loaded = sum(1 for v in status["modules"].values() if v)
+    total = len(status["modules"])
+    print(f"[Init] {loaded}/{total} modules chargés — session {status['session']['session_id']}\n")
+
+    while True:
+        try:
+            user_input = input("Vous : ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nAu revoir.")
+            break
+
+        if not user_input:
+            continue
+
+        cmd = COMMANDS.get(user_input.lower())
+        if cmd:
+            action, payload = cmd(orch)
+            if action == "exit":
+                print("ALFRED : À bientôt.")
+                break
+            elif action == "print":
+                print(payload)
+            elif action == "reset":
+                orch.reset_session()
+                print("[Session réinitialisée]")
+            elif action == "mode":
+                orch.set_mode(payload)
+                print(f"[Mode → {payload}]")
+            continue
+
+        resp = orch.process(user_input)
+
+        prefix = ""
+        if resp.blocked:
+            prefix = "[PROTÉGÉ] "
+        elif resp.fallback:
+            prefix = "[hors ligne] "
+
+        print(f"\nALFRED : {prefix}{resp.text}\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/src/v3/orchestrator/__init__.py
+++ b/src/v3/orchestrator/__init__.py
@@ -1,1 +1,4 @@
-﻿# ALFRED module
+﻿from src.v3.orchestrator.alfred_orchestrator import AlfredOrchestrator
+from src.v3.orchestrator.pipeline import OrchestratorResponse
+
+__all__ = ["AlfredOrchestrator", "OrchestratorResponse"]

--- a/src/v3/orchestrator/alfred_orchestrator.py
+++ b/src/v3/orchestrator/alfred_orchestrator.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""
+alfred_orchestrator.py — ALFRED V3 Orchestrateur principal
+
+Point d'entrée unique pour traiter une entrée utilisateur.
+Coordonne tous les modules via ProcessingPipeline.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Optional
+
+from src.v3.orchestrator.pipeline import OrchestratorResponse, ProcessingPipeline
+from src.v3.orchestrator.state_manager import SessionState
+
+
+class AlfredOrchestrator:
+    """
+    Interface publique de l'orchestrateur ALFRED V3.
+
+    Usage :
+        orch = AlfredOrchestrator(personality_path=..., user_profile_path=...)
+        resp = orch.process("Bonjour ALFRED")
+        print(resp.text)
+    """
+
+    def __init__(
+        self,
+        personality_path: str,
+        user_profile_path: str,
+        memory_path: str = "data/memory/episodic/dialogue_history.json",
+        config: Optional[Dict[str, Any]] = None,
+        debug: bool = False,
+    ):
+        self.debug = debug
+        self._session_id = str(uuid.uuid4())[:8]
+
+        self._pipeline = ProcessingPipeline(
+            personality_path=personality_path,
+            user_profile_path=user_profile_path,
+            memory_path=memory_path,
+            config=config or {},
+            debug=debug,
+        )
+        self._state = SessionState(session_id=self._session_id)
+
+    # ── API publique ──────────────────────────────────────
+
+    def process(self, user_input: str) -> OrchestratorResponse:
+        """Traite une entrée utilisateur et retourne une réponse complète."""
+        return self._pipeline.run(user_input.strip(), self._state)
+
+    def reset_session(self) -> None:
+        """Démarre une nouvelle session (réinitialise état + identifiant)."""
+        self._session_id = str(uuid.uuid4())[:8]
+        self._state = SessionState(session_id=self._session_id)
+
+    def set_mode(self, mode: str) -> None:
+        """Force un mode ALFRED (support / focus / challenge / complicite)."""
+        self._state.update_mode(mode)
+        if mm := self._pipeline._m.get("mode_manager"):
+            try:
+                mm.set_mode(mode, reason="manual_override")
+            except Exception:
+                pass
+
+    def get_status(self) -> Dict[str, Any]:
+        """Retourne l'état complet de l'orchestrateur et de ses modules."""
+        return {
+            "session": self._state.to_dict(),
+            "modules": self._pipeline.get_module_status(),
+            "rag": self._get_rag_status(),
+        }
+
+    # ── Helpers internes ──────────────────────────────────
+
+    def _get_rag_status(self) -> Dict[str, Any]:
+        if rag := self._pipeline._m.get("rag"):
+            try:
+                return rag.get_status()
+            except Exception:
+                pass
+        return {"available": False}

--- a/src/v3/orchestrator/context_builder.py
+++ b/src/v3/orchestrator/context_builder.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+context_builder.py — ALFRED V3
+Assemble le contexte supplémentaire à injecter dans le prompt LLM.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+class ContextBuilder:
+    """
+    Construit un bloc textuel enrichi pour le prompt système :
+    RAG sémantique + knowledge routing + wellbeing hint.
+    Ces éléments viennent s'ajouter au contexte standard de ResponseGenerator.
+    """
+
+    def build_extra_system_block(
+        self,
+        rag_results: Optional[List[Dict[str, Any]]] = None,
+        knowledge_context: Optional[Dict[str, Any]] = None,
+        wellbeing_suggestion: Optional[str] = None,
+        state_dict: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        blocks: List[str] = []
+
+        rag_block = self._format_rag(rag_results or [])
+        if rag_block:
+            blocks.append(rag_block)
+
+        know_block = self._format_knowledge(knowledge_context or {})
+        if know_block:
+            blocks.append(know_block)
+
+        if wellbeing_suggestion:
+            blocks.append(f"[Suggestion bien-être] {wellbeing_suggestion}")
+
+        if state_dict:
+            mode = state_dict.get("current_mode", "")
+            emotion = state_dict.get("current_emotion", "")
+            if mode or emotion:
+                blocks.append(f"[État session] Mode : {mode} | Émotion : {emotion}")
+
+        return "\n\n".join(blocks)
+
+    # ── Formateurs privés ─────────────────────────────────
+
+    def _format_rag(self, results: List[Dict[str, Any]]) -> str:
+        if not results:
+            return ""
+        lines = ["[Mémoire sémantique pertinente]"]
+        for r in results[:3]:
+            doc = r.get("document", "").strip()
+            score = r.get("score", 0.0)
+            if doc:
+                lines.append(f"• (pertinence {score:.2f}) {doc[:250]}")
+        return "\n".join(lines) if len(lines) > 1 else ""
+
+    def _format_knowledge(self, ctx: Dict[str, Any]) -> str:
+        if not ctx:
+            return ""
+        # Format RetrievalEngine result
+        prompt_block = ctx.get("prompt_block", "")
+        if prompt_block:
+            return str(prompt_block)[:600]
+        # Format legacy dict
+        domain = ctx.get("domain", "")
+        content = ctx.get("content", "")
+        if not content:
+            return ""
+        header = f"[Knowledge — {domain}]" if domain else "[Knowledge]"
+        return f"{header}\n{str(content)[:400]}"

--- a/src/v3/orchestrator/pipeline.py
+++ b/src/v3/orchestrator/pipeline.py
@@ -1,0 +1,400 @@
+# -*- coding: utf-8 -*-
+"""
+pipeline.py — ALFRED V3 Processing Pipeline
+
+14 étapes ordonnées, chacune avec fallback gracieux.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from src.v3.orchestrator.state_manager import SessionState
+from src.v3.orchestrator.context_builder import ContextBuilder
+
+
+@dataclass
+class OrchestratorResponse:
+    text: str
+    mode: str
+    emotion_detected: str
+    session_id: str
+    turn: int
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    rag_hits: int = 0
+    fallback: bool = False
+    blocked: bool = False
+
+
+class ProcessingPipeline:
+    """
+    Pipeline de traitement ALFRED V3.
+    Chaque module est chargé avec try/except — rien ne plante le pipeline.
+    """
+
+    def __init__(
+        self,
+        personality_path: str,
+        user_profile_path: str,
+        memory_path: str,
+        config: Dict[str, Any],
+        debug: bool = False,
+    ):
+        self.debug = debug
+        self._m: Dict[str, Any] = {}
+        self._ctx_builder = ContextBuilder()
+        self._load_modules(personality_path, user_profile_path, memory_path)
+
+    # ── Chargement modules ────────────────────────────────
+
+    def _load_modules(
+        self,
+        personality_path: str,
+        user_profile_path: str,
+        memory_path: str,
+    ) -> None:
+        self._try_load("emotion_detect", "src.regulation.emotion_detector", "detect_emotion")
+        self._try_load("mode_manager", "src.regulation.mode_manager", "get_mode_manager", call=True)
+        self._try_load("analyze_wellbeing", "src.regulation.wellbeing_tracker", "analyze_wellbeing")
+        self._try_load("wellbeing_suggest", "src.regulation.wellbeing_tracker", "get_wellbeing_suggestion")
+        self._try_load("is_crisis", "src.regulation.protection_guard", "is_crisis")
+        self._try_load("block_content", "src.regulation.protection_guard", "should_block_content")
+        self._try_load("crisis_response", "src.regulation.protection_guard", "get_crisis_response")
+        self._try_load("ethical_check", "src.regulation.protection_guard", "check_ethical_boundaries")
+        self._try_load("answer_from_memory", "src.memory.memory_answer_engine", "answer_from_memory")
+        # RetrievalEngine (remplace le deprecated knowledge_router)
+        try:
+            from src.knowledge.retrieval_engine import KnowledgeRetrievalEngine as RetrievalEngine
+            import os
+            project_root = str(Path(__file__).resolve().parent.parent.parent.parent)
+            self._m["retrieval_engine"] = RetrievalEngine(project_root=project_root)
+        except Exception as e:
+            self._warn("retrieval_engine", e)
+
+        # MemoryEngine
+        try:
+            from src.memory.memory_engine import MemoryEngine
+            self._m["memory"] = MemoryEngine(history_path=memory_path)
+        except Exception as e:
+            self._warn("memory_engine", e)
+
+        # LongTermMemory
+        try:
+            import src.memory.long_term_memory as ltm
+            ltm.init_db()
+            self._m["ltm"] = ltm
+        except Exception as e:
+            self._warn("long_term_memory", e)
+
+        # RAG
+        try:
+            from src.rag.rag_engine import RAGEngine
+            self._m["rag"] = RAGEngine()
+        except Exception as e:
+            self._warn("rag_engine", e)
+
+        # PersonalityAdapter
+        try:
+            from src.core.personality_adapter import PersonalityAdapter
+            self._m["personality"] = PersonalityAdapter(
+                personality_path=personality_path,
+                user_profile_path=user_profile_path,
+            )
+        except Exception as e:
+            self._warn("personality_adapter", e)
+
+        # BehaviorEngine — utilise le fichier personnalité comme identity par défaut
+        try:
+            from src.core.alfred_behavior_engine import AlfredBehaviorEngine, UserState
+            self._m["behavior"] = AlfredBehaviorEngine(identity_path=personality_path)
+            self._m["UserState"] = UserState
+        except Exception as e:
+            self._warn("behavior_engine", e)
+
+        # LLM + ResponseGenerator
+        try:
+            from src.llm.llm_client_ollama import OllamaLLMClient
+            from src.llm.llm_router import LLMRouter
+            self._m["llm"] = LLMRouter(primary=OllamaLLMClient(), allow_cloud_fallback=False)
+        except Exception as e:
+            self._warn("llm_router", e)
+
+        try:
+            from src.core.response_generator import ResponseGenerator
+            self._m["response_gen"] = ResponseGenerator(
+                llm_client=self._m.get("llm"),
+                debug=self.debug,
+            )
+        except Exception as e:
+            self._warn("response_generator", e)
+
+    def _try_load(
+        self, key: str, module: str, attr: str, call: bool = False
+    ) -> None:
+        try:
+            import importlib
+            mod = importlib.import_module(module)
+            obj = getattr(mod, attr)
+            self._m[key] = obj() if call else obj
+        except Exception as e:
+            self._warn(key, e)
+
+    def _warn(self, name: str, error: Exception) -> None:
+        if self.debug:
+            print(f"[PIPELINE] ⚠ {name} indisponible : {error}")
+
+    # ── Pipeline principal ────────────────────────────────
+
+    def run(self, user_input: str, state: SessionState) -> OrchestratorResponse:
+        state.increment_turn()
+
+        # ── 1. Crise / blocage input ──────────────────────
+        if fn := self._m.get("is_crisis"):
+            if fn(user_input):
+                crisis_text = self._m["crisis_response"]() if "crisis_response" in self._m else (
+                    "Je t'entends. Si tu traverses quelque chose de difficile, parles-en "
+                    "à un professionnel de santé. Je suis là pour t'accompagner, pas te remplacer."
+                )
+                return OrchestratorResponse(
+                    text=crisis_text,
+                    mode=state.current_mode,
+                    emotion_detected="crisis",
+                    session_id=state.session_id,
+                    turn=state.turn_count,
+                    blocked=True,
+                )
+
+        if fn := self._m.get("block_content"):
+            if fn(user_input):
+                return OrchestratorResponse(
+                    text="Je ne peux pas traiter cette demande.",
+                    mode=state.current_mode,
+                    emotion_detected=state.current_emotion,
+                    session_id=state.session_id,
+                    turn=state.turn_count,
+                    blocked=True,
+                )
+
+        # ── 2. Détection émotion ──────────────────────────
+        emotional_state = None
+        if fn := self._m.get("emotion_detect"):
+            try:
+                emotional_state = fn(user_input)
+                state.update_emotion(emotional_state.emotion, emotional_state.intensity)
+            except Exception:
+                pass
+
+        # ── 3. Wellbeing ──────────────────────────────────
+        wellbeing_suggestion: Optional[str] = None
+        if fn := self._m.get("analyze_wellbeing"):
+            try:
+                wb = fn(
+                    emotion=state.current_emotion,
+                    intensity=state.emotion_intensity,
+                    hour=datetime.now().hour,
+                )
+                state.wellbeing_energy = wb.energy_level
+                if suggest := self._m.get("wellbeing_suggest"):
+                    wellbeing_suggestion = suggest(wb)
+            except Exception:
+                pass
+
+        # ── 4. Mode ───────────────────────────────────────
+        mode_guidelines = ""
+        if mm := self._m.get("mode_manager"):
+            try:
+                if emotional_state:
+                    new_mode = mm.update_from_emotion(emotional_state)
+                    state.update_mode(new_mode)
+                mode_guidelines = mm.get_response_guidelines()
+            except Exception:
+                pass
+
+        # ── 5. Mémoire épisodique ─────────────────────────
+        memory_context = ""
+        if mem := self._m.get("memory"):
+            try:
+                memory_context = mem.format_context_for_prompt()
+            except Exception:
+                pass
+
+        # ── 6. Réponse directe depuis mémoire ─────────────
+        if fn := self._m.get("answer_from_memory"):
+            try:
+                direct = fn(user_input, memory_context)
+                if direct:
+                    self._memorize(user_input, direct, state)
+                    return OrchestratorResponse(
+                        text=direct,
+                        mode=state.current_mode,
+                        emotion_detected=state.current_emotion,
+                        session_id=state.session_id,
+                        turn=state.turn_count,
+                    )
+            except Exception:
+                pass
+
+        # ── 7. RAG sémantique ─────────────────────────────
+        rag_results: List[Dict[str, Any]] = []
+        if rag := self._m.get("rag"):
+            try:
+                rag_results = rag.search_memories(user_input, n_results=3)
+            except Exception:
+                pass
+
+        # ── 8. Knowledge routing ──────────────────────────
+        knowledge_context: Dict[str, Any] = {}
+        if re_engine := self._m.get("retrieval_engine"):
+            try:
+                result = re_engine.retrieve(query=user_input)
+                knowledge_context = {
+                    "prompt_block": result.prompt_block,
+                    "domains": result.domains,
+                    "knowledge_ids": result.knowledge_ids,
+                }
+            except Exception:
+                pass
+
+        # ── 9. Contexte enrichi (RAG + knowledge + état) ──
+        extra_block = self._ctx_builder.build_extra_system_block(
+            rag_results=rag_results,
+            knowledge_context=knowledge_context,
+            wellbeing_suggestion=wellbeing_suggestion,
+            state_dict=state.to_dict(),
+        )
+
+        # ── 10. Personnalité ──────────────────────────────
+        response_context: Dict[str, Any] = {}
+        if pa := self._m.get("personality"):
+            try:
+                response_context = pa.build_response_context(
+                    user_message=user_input,
+                    detected_emotion=state.current_emotion if state.current_emotion != "neutral" else None,
+                    energy_level=state.wellbeing_energy if state.wellbeing_energy != "normal" else None,
+                )
+            except Exception:
+                pass
+
+        # ── 11. Comportement ──────────────────────────────
+        behavior_block = ""
+        if be := self._m.get("behavior"):
+            try:
+                UserState = self._m["UserState"]
+                us = UserState(
+                    emotion=state.current_emotion,
+                    intensity=state.emotion_intensity,
+                    intent=state.last_intent,
+                )
+                decision = be.decide_behavior(us, user_message=user_input)
+                behavior_block = be.build_prompt_context(decision)
+            except Exception:
+                pass
+
+        # Injecter le bloc comportemental dans mode_guidelines
+        full_guidelines = "\n\n".join(
+            part for part in [mode_guidelines, behavior_block, extra_block] if part
+        )
+
+        # ── 12. Génération réponse ────────────────────────
+        response_text = ""
+        fallback = False
+        if rg := self._m.get("response_gen"):
+            try:
+                response_text = rg.generate_response(
+                    user_message=user_input,
+                    response_context=response_context,
+                    history_text=memory_context,
+                    mode_guidelines=full_guidelines,
+                )
+            except Exception:
+                fallback = True
+        else:
+            fallback = True
+
+        if fallback or not response_text:
+            response_text = self._offline_response(state)
+            fallback = True
+
+        # ── 13. Filtre éthique output ─────────────────────
+        if fn := self._m.get("ethical_check"):
+            try:
+                check = fn(response_text)
+                if not check.get("passed", True) and check.get("alerts"):
+                    if self.debug:
+                        print(f"[ETHICS] alertes : {check['alerts']}")
+            except Exception:
+                pass
+
+        # ── 14. Mémorisation ──────────────────────────────
+        self._memorize(user_input, response_text, state)
+
+        return OrchestratorResponse(
+            text=response_text,
+            mode=state.current_mode,
+            emotion_detected=state.current_emotion,
+            session_id=state.session_id,
+            turn=state.turn_count,
+            rag_hits=len(rag_results),
+            fallback=fallback,
+        )
+
+    # ── Helpers ───────────────────────────────────────────
+
+    def _memorize(
+        self, user_input: str, response: str, state: SessionState
+    ) -> None:
+        if mem := self._m.get("memory"):
+            try:
+                mem.save_exchange("user", user_input, intent=state.last_intent)
+                mem.save_exchange("alfred", response)
+            except Exception:
+                pass
+
+        if ltm := self._m.get("ltm"):
+            try:
+                ltm.save_exchange(
+                    session_id=state.session_id,
+                    role="user",
+                    content=user_input,
+                    intent=state.last_intent,
+                    emotion=state.current_emotion,
+                )
+                ltm.save_exchange(
+                    session_id=state.session_id,
+                    role="alfred",
+                    content=response,
+                )
+            except Exception:
+                pass
+
+        if rag := self._m.get("rag"):
+            try:
+                rag.index_exchange(
+                    user_input=user_input,
+                    response=response,
+                    session_id=state.session_id,
+                    turn=state.turn_count,
+                )
+            except Exception:
+                pass
+
+    def _offline_response(self, state: SessionState) -> str:
+        prefixes = {
+            "support": "Je t'entends.",
+            "focus": "Voilà ce que je peux dire pour l'instant.",
+            "challenge": "On va travailler ça ensemble.",
+            "complicite": "Bonne question !",
+        }
+        return prefixes.get(state.current_mode, "Je suis là.") + " [mode hors ligne]"
+
+    def get_module_status(self) -> Dict[str, bool]:
+        keys = [
+            "emotion_detect", "mode_manager", "analyze_wellbeing",
+            "is_crisis", "memory", "ltm", "rag",
+            "retrieval_engine", "personality", "behavior",
+            "llm", "response_gen",
+        ]
+        return {k: k in self._m for k in keys}

--- a/src/v3/orchestrator/state_manager.py
+++ b/src/v3/orchestrator/state_manager.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+state_manager.py — ALFRED V3
+État de session persistant sur la durée d'une conversation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict
+
+
+@dataclass
+class SessionState:
+    session_id: str
+    turn_count: int = 0
+    current_mode: str = "focus"
+    current_emotion: str = "neutral"
+    emotion_intensity: float = 0.0
+    wellbeing_energy: str = "normal"
+    last_intent: str = "general_discussion"
+    context: Dict[str, Any] = field(default_factory=dict)
+    active_since: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    def increment_turn(self) -> None:
+        self.turn_count += 1
+
+    def update_emotion(self, emotion: str, intensity: float) -> None:
+        self.current_emotion = emotion
+        self.emotion_intensity = intensity
+
+    def update_mode(self, mode: str) -> None:
+        self.current_mode = mode
+
+    def set(self, key: str, value: Any) -> None:
+        self.context[key] = value
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.context.get(key, default)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "turn_count": self.turn_count,
+            "current_mode": self.current_mode,
+            "current_emotion": self.current_emotion,
+            "emotion_intensity": self.emotion_intensity,
+            "wellbeing_energy": self.wellbeing_energy,
+            "last_intent": self.last_intent,
+            "active_since": self.active_since,
+        }


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

Session remote — avatar/TTS mis de côté. Avancement sur les modules cognitifs V3.

### V3 Orchestrateur (`src/v3/orchestrator/`)

- **`alfred_orchestrator.py`** — API publique : `process()`, `set_mode()`, `reset_session()`, `get_status()`
- **`pipeline.py`** — 14 étapes ordonnées avec fallback gracieux sur chaque module
- **`context_builder.py`** — assemble le bloc enrichi (RAG + knowledge + wellbeing) pour le prompt LLM
- **`state_manager.py`** — `SessionState` persistant : émotion, mode, wellbeing, intent, turn count

### RAG Engine (`src/rag/`)

- **`chroma_store.py`** — wrapper ChromaDB avec fallback keyword automatique si `chromadb` non installé
- **`rag_engine.py`** — deux collections : `alfred_memory` (échanges) + `alfred_knowledge` (documents), search sémantique fusionné
- **`__init__.py`** — exports publics

### Point d'entrée V3 (`src/v3/main_alfred_v3.py`)

Pipeline texte complet via orchestrateur, commandes intégrées : `statut`, `reset`, `mode support/focus/challenge/complicite`

## Validation

- 12/12 modules chargés en session remote
- Détection émotion opérationnelle → transition de mode automatique (`stressed → support`)
- `MemoryAnswerEngine` intercepte les questions mémoire sans appel LLM
- RAG fallback keyword fonctionnel (ChromaDB optionnel, s'active automatiquement si installé)
- Pipeline stable si Ollama absent (mode dégradé propre)

## Plan de test

- [ ] Lancer `python -m src.v3.main_alfred_v3` avec Ollama actif
- [ ] Vérifier la commande `statut` affiche 12/12 modules
- [ ] Tester la transition de mode sur message émotionnel
- [ ] Installer `chromadb` et vérifier le passage du backend keyword → ChromaDB
- [ ] Tester la recherche RAG sur échanges précédents

https://claude.ai/code/session_01PwjxcUa8ej9FU1JsczEGhJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwjxcUa8ej9FU1JsczEGhJ)_